### PR TITLE
Bug fixes to workspace clear, select, create, init process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] - 2020-11-01
+## [1.0.1] - 2020-11-01
 
 - Fixed issue with `Clear-TerraformEnvironment` unnecessarily running every time, causing workspace change every time
 - Fixed issue with `Set-TerraformWorkspace` not running `terraform init` after a workspace change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0] - 2020-11-01
+
+- Fixed issue with `Clear-TerraformEnvironment` unnecessarily running every time, causing workspace change every time
+- Fixed issue with `Set-TerraformWorkspace` not running `terraform init` after a workspace change
+- Fixed issue with `Set-TerraformWorkspace` using `-cmatch` vs `-ccontains` causing issues when workspaces were a substring of another workspace
+
+## [1.0.0] - 2020-02-29
+
+- Initial release

--- a/terraposh.psd1
+++ b/terraposh.psd1
@@ -12,7 +12,7 @@
     RootModule           = 'terraposh.psm1'
 
     # Version number of this module.
-    ModuleVersion        = '1.0.0'
+    ModuleVersion        = '1.0.1'
 
     # Supported PSEditions
     CompatiblePSEditions = @('Core')


### PR DESCRIPTION
Addressed several issues related to issue #7:
- Fixed issue with `Clear-TerraformEnvironment` unnecessarily running every time, causing workspace change every time
- Fixed issue with `Set-TerraformWorkspace` not running `terraform init` after a workspace change
- Fixed issue with `Set-TerraformWorkspace` using `-cmatch` vs `-ccontains` causing issues when workspaces were a substring of another workspace