### PR TITLE
Add SkipWorkspace parameter

### DIFF
--- a/.terraposh.config.json
+++ b/.terraposh.config.json
@@ -1,6 +1,7 @@
 {
     "TerraformVersion": "",
     "CreateHardLink": false,
+    "SkipWorkspace": false,
     "TF_CLI_ARGS_init": "",
     "TF_CLI_ARGS_plan": "",
     "TF_CLI_ARGS_apply": "",

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The config file can contain any number of `TF_CLI_ARGS` and they will all be loa
 {
     "TerraformVersion": "1.6.3",
     "CreateHardLink": true,
+    "SkipWorkspace": false,
     "TF_CLI_ARGS_init": "-backend=true -upgrade=true -backend-config=backend.tfvars -reconfigure",
     "TF_CLI_ARGS_plan": "-detailed-exitcode -parallelism=20 -out=.terraform/plan.bin -var-file=development.tfvars",
     "TF_CLI_ARGS_apply": "-parallelism=20 .terraform/plan.bin",
@@ -70,6 +71,7 @@ All functions support the same params.
 [switch]$Explicit         # Used to bypass automatic sequencing of init, workspace, <command> and will instead just run the provided command only
 [string]$Version          # The version of Terraform to run, will automatically be downloaded if not already vendored
 [switch]$CreateHardLink   # If present, Terraposh will automatically create a HardLink to the Terraform vendored binary
+[switch]$SkipWorkspace    # If present, Terraposh will skip the creation of a Terraform workspace during the init, plan, apply, and destroy process
 ```
 
 ### `terraposh` or `Invoke-Terraposh`
@@ -87,6 +89,7 @@ SYNTAX
         [-Explicit]
         [-Version <string>]
         [-CreateHardLink]
+        [-SkipWorkspace]
 
 ALIASES
     terraposh
@@ -107,6 +110,7 @@ SYNTAX
         [-Explicit]
         [-Version <string>]
         [-CreateHardLink]
+        [-SkipWorkspace]
 
 ALIASES
     tpp
@@ -127,6 +131,7 @@ SYNTAX
         [-Explicit]
         [-Version <string>]
         [-CreateHardLink]
+        [-SkipWorkspace]
 
 ALIASES
     tpa
@@ -147,6 +152,7 @@ SYNTAX
         [-Explicit]
         [-Version <string>]
         [-CreateHardLink]
+        [-SkipWorkspace]
 
 ALIASES
     tpd
@@ -167,6 +173,7 @@ SYNTAX
         [-Explicit]
         [-Version <string>]
         [-CreateHardLink]
+        [-SkipWorkspace]
 
 ALIASES
     tpda

--- a/terraposh.psm1
+++ b/terraposh.psm1
@@ -42,6 +42,9 @@ function Invoke-Terraposh {
 
         $TerraformCommand = $TerraformCommand.Trim()
 
+        # Determine if workspace management should be skipped
+        $ShouldSkipWorkspace = $SkipWorkspace -or $Config.SkipWorkspace
+
         # If not explicit, sequence for laziness
         if ($Explicit) {
             Invoke-TerraformCommand -Command $TerraformCommand @TerraformCommandSplat
@@ -57,7 +60,7 @@ function Invoke-Terraposh {
                         Invoke-TerraformCommand -Command 'init' @TerraformCommandSplat
                     }
 
-                    if (-not $SkipWorkspace -and -not $Config.SkipWorkspace) {
+                    if (-not $ShouldSkipWorkspace) {
                         Set-TerraformWorkspace -Workspace $Workspace -InitOnChange @TerraformCommandSplat
                     }
                     Invoke-TerraformCommand -Command $TerraformCommand @TerraformCommandSplat
@@ -71,7 +74,7 @@ function Invoke-Terraposh {
                         Invoke-TerraformCommand -Command 'init' @TerraformCommandSplat
                     }
 
-                    if (-not $SkipWorkspace -and -not $Config.SkipWorkspace) {
+                    if (-not $ShouldSkipWorkspace) {
                         $Workspace = Set-TerraformWorkspace -Workspace $Workspace -InitOnChange -PassThru @TerraformCommandSplat
                         Invoke-TerraformCommand -Command $TerraformCommand @TerraformCommandSplat
                         
@@ -143,7 +146,7 @@ function Get-Config {
         [string]$File
     )
 
-    # serach order/precedence (last wins)
+    # search order/precedence (last wins)
     # - user profile ~/.terraposh.config.json
     # - git repo search (if in git repo), top of repo -> closest to working directory
     # - file param

--- a/terraposh.psm1
+++ b/terraposh.psm1
@@ -17,7 +17,8 @@ function Invoke-Terraposh {
         [string]$Workspace,
         [switch]$Explicit,
         [string]$Version,
-        [switch]$CreateHardLink
+        [switch]$CreateHardLink,
+        [switch]$SkipWorkspace
     )
 
     # Push to directory
@@ -56,7 +57,9 @@ function Invoke-Terraposh {
                         Invoke-TerraformCommand -Command 'init' @TerraformCommandSplat
                     }
 
-                    Set-TerraformWorkspace -Workspace $Workspace -InitOnChange @TerraformCommandSplat
+                    if (-not $SkipWorkspace -and -not $Config.SkipWorkspace) {
+                        Set-TerraformWorkspace -Workspace $Workspace -InitOnChange @TerraformCommandSplat
+                    }
                     Invoke-TerraformCommand -Command $TerraformCommand @TerraformCommandSplat
                 }
                 '^destroy' {
@@ -68,12 +71,17 @@ function Invoke-Terraposh {
                         Invoke-TerraformCommand -Command 'init' @TerraformCommandSplat
                     }
 
-                    $Workspace = Set-TerraformWorkspace -Workspace $Workspace -InitOnChange -PassThru @TerraformCommandSplat
-                    Invoke-TerraformCommand -Command $TerraformCommand @TerraformCommandSplat
-                    
-                    if ($Workspace -ne 'default') {
-                        Set-TerraformWorkspace -Workspace 'default' @TerraformCommandSplat
-                        Invoke-TerraformCommand -Command "workspace delete ${Workspace}" @TerraformCommandSplat
+                    if (-not $SkipWorkspace -and -not $Config.SkipWorkspace) {
+                        $Workspace = Set-TerraformWorkspace -Workspace $Workspace -InitOnChange -PassThru @TerraformCommandSplat
+                        Invoke-TerraformCommand -Command $TerraformCommand @TerraformCommandSplat
+                        
+                        if ($Workspace -ne 'default') {
+                            Set-TerraformWorkspace -Workspace 'default' @TerraformCommandSplat
+                            Invoke-TerraformCommand -Command "workspace delete ${Workspace}" @TerraformCommandSplat
+                        }
+                    }
+                    else {
+                        Invoke-TerraformCommand -Command $TerraformCommand @TerraformCommandSplat
                     }
                 }
                 default { Invoke-TerraformCommand -Command $TerraformCommand @TerraformCommandSplat }
@@ -417,7 +425,8 @@ function Invoke-TerraposhPlan {
         [string]$Workspace,
         [switch]$Explicit,
         [string]$Version,
-        [switch]$CreateHardLink
+        [switch]$CreateHardLink,
+        [switch]$SkipWorkspace
     )
 
     $PSBoundParameters.Remove('TerraformCommand') | Out-Null
@@ -433,7 +442,8 @@ function Invoke-TerraposhApply {
         [string]$Workspace,
         [switch]$Explicit,
         [string]$Version,
-        [switch]$CreateHardLink
+        [switch]$CreateHardLink,
+        [switch]$SkipWorkspace
     )
 
     $PSBoundParameters.Remove('TerraformCommand') | Out-Null
@@ -449,7 +459,8 @@ function Invoke-TerraposhDestroy {
         [string]$Workspace,
         [switch]$Explicit,
         [string]$Version,
-        [switch]$CreateHardLink
+        [switch]$CreateHardLink,
+        [switch]$SkipWorkspace
     )
 
     $PSBoundParameters.Remove('TerraformCommand') | Out-Null
@@ -465,7 +476,8 @@ function Invoke-TerraposhDestroyAutoApprove {
         [string]$Workspace,
         [switch]$Explicit,
         [string]$Version,
-        [switch]$CreateHardLink
+        [switch]$CreateHardLink,
+        [switch]$SkipWorkspace
     )
 
     $PSBoundParameters.Remove('TerraformCommand') | Out-Null


### PR DESCRIPTION
When using Terraposh, the default behavior is to create a new terraform workspace based on the name of the git branch. If you are using Terraform Cloud and are using the `cloud` configuration block inside the `terraform` block, then Terraposh will error when creating a new workspace because custom workspaces are not allowed.

To fix this issue, I have added a new parameter `SkipWorkspace` to the module. If this is set to true on the command line or in the config file, then Terraposh will skip the creation and teardown of a workspace as part of the plan/apply/destroy process.
